### PR TITLE
Exercise JSON export draft

### DIFF
--- a/Controller/Api/ExerciseController.php
+++ b/Controller/Api/ExerciseController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace UJM\ExoBundle\Controller\Api;
+
+use JMS\DiExtraBundle\Annotation as DI;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration as EXT;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use UJM\ExoBundle\Entity\Exercise;
+use UJM\ExoBundle\Manager\ExerciseManager;
+
+/**
+ * @EXT\Route(requirements={"id"="\d+"}, options={"expose"=true})
+ * @EXT\Method("GET")
+ */
+class ExerciseController
+{
+    private $manager;
+
+    /**
+     * @DI\InjectParams({
+     *     "manager" = @DI\Inject("ujm.exo.exercise_manager")
+     * })
+     *
+     * @param ExerciseManager $manager
+     */
+    public function __construct(ExerciseManager $manager)
+    {
+        $this->manager = $manager;
+    }
+
+    /**
+     * @EXT\Route("/exercises/{id}")
+     */
+    public function exerciseAction(Exercise $exercise)
+    {
+        return new JsonResponse($this->manager->exportExercise($exercise));
+    }
+}

--- a/Entity/Exercise.php
+++ b/Entity/Exercise.php
@@ -2,6 +2,7 @@
 
 namespace UJM\ExoBundle\Entity;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 use Claroline\CoreBundle\Entity\Resource\AbstractResource;
 
@@ -21,7 +22,7 @@ class Exercise extends AbstractResource
     private $title;
 
     /**
-     * @var text $description
+     * @var string $description
      *
      * @ORM\Column(name="description", type="text", nullable=true)
      */
@@ -32,7 +33,7 @@ class Exercise extends AbstractResource
      *
      * @ORM\Column(name="shuffle", type="boolean", nullable=true)
      */
-    private $shuffle;
+    private $shuffle = false;
 
     /**
      * @var integer $nbQuestion
@@ -49,7 +50,7 @@ class Exercise extends AbstractResource
     private $keepSameQuestion;
 
     /**
-     * @var datetime $dateCreate
+     * @var \Datetime $dateCreate
      *
      * @ORM\Column(name="date_create", type="datetime")
      */
@@ -74,7 +75,7 @@ class Exercise extends AbstractResource
      *
      * @ORM\Column(name="doprint", type="boolean", nullable=true)
      */
-    private $doprint;
+    private $doprint = false;
 
     /**
      * @var integer $maxAttempts
@@ -91,7 +92,7 @@ class Exercise extends AbstractResource
     private $correctionMode;
 
     /**
-     * @var datetime $dateCorrection
+     * @var \Datetime $dateCorrection
      *
      * @ORM\Column(name="date_correction", type="datetime", nullable=true)
      */
@@ -105,7 +106,7 @@ class Exercise extends AbstractResource
     private $markMode;
 
     /**
-     * @var datetime $startDate
+     * @var \Datetime $startDate
      *
      * @ORM\Column(name="start_date", type="datetime")
      */
@@ -119,7 +120,7 @@ class Exercise extends AbstractResource
     private $useDateEnd;
 
     /**
-     * @var datetime $end_date
+     * @var \Datetime $end_date
      *
      * @ORM\Column(name="end_date", type="datetime", nullable=true)
      */
@@ -130,14 +131,14 @@ class Exercise extends AbstractResource
      *
      * @ORM\Column(name="disp_button_interrupt", type="boolean", nullable=true)
      */
-    private $dispButtonInterrupt;
+    private $dispButtonInterrupt = false;
 
     /**
      * @var boolean $lockAttempt
      *
      * @ORM\Column(name="lock_attempt", type="boolean", nullable=true)
      */
-    private $lockAttempt;
+    private $lockAttempt = false;
 
     /**
      * @ORM\ManyToMany(targetEntity="UJM\ExoBundle\Entity\Groupes")
@@ -157,15 +158,11 @@ class Exercise extends AbstractResource
      *
      * @ORM\Column(name="published", type="boolean")
      */
-    private $published;
+    private $published = false;
 
     public function __construct()
     {
-        $this->groupes = new \Doctrine\Common\Collections\ArrayCollection;
-        $this->lockAttempt = false;
-        $this->dispButtonInterrupt  = false;
-        $this->doprint = false;
-        $this->shuffle = false;
+        $this->groupes = new ArrayCollection();
     }
 
     /**
@@ -201,7 +198,7 @@ class Exercise extends AbstractResource
     /**
      * Set description
      *
-     * @param text $description
+     * @param string $description
      */
     public function setDescription($description)
     {
@@ -211,7 +208,7 @@ class Exercise extends AbstractResource
     /**
      * Get description
      *
-     * @return text
+     * @return string
      */
     public function getDescription()
     {
@@ -277,9 +274,9 @@ class Exercise extends AbstractResource
     /**
      * Set dateCreate
      *
-     * @param datetime $dateCreate
+     * @param \Datetime $dateCreate
      */
-    public function setDateCreate($dateCreate)
+    public function setDateCreate(\DateTime $dateCreate)
     {
         $this->dateCreate = $dateCreate;
     }
@@ -287,7 +284,7 @@ class Exercise extends AbstractResource
     /**
      * Get dateCreate
      *
-     * @return datetime
+     * @return \Datetime
      */
     public function getDateCreate()
     {
@@ -395,9 +392,9 @@ class Exercise extends AbstractResource
     /**
      * Set dateCorrection
      *
-     * @param datetime $dateCorrection
+     * @param \Datetime $dateCorrection
      */
-    public function setDateCorrection($dateCorrection)
+    public function setDateCorrection(\DateTime $dateCorrection)
     {
         $this->dateCorrection = $dateCorrection;
     }
@@ -405,7 +402,7 @@ class Exercise extends AbstractResource
     /**
      * Get dateCorrection
      *
-     * @return datetime
+     * @return \Datetime
      */
     public function getDateCorrection()
     {
@@ -435,9 +432,9 @@ class Exercise extends AbstractResource
     /**
      * Set startDate
      *
-     * @param datetime $startDate
+     * @param \DateTime $startDate
      */
-    public function setStartDate($startDate)
+    public function setStartDate(\DateTime $startDate)
     {
         $this->startDate = $startDate;
     }
@@ -445,7 +442,7 @@ class Exercise extends AbstractResource
     /**
      * Get startDate
      *
-     * @return datetime
+     * @return \Datetime
      */
     public function getStartDate()
     {
@@ -473,9 +470,9 @@ class Exercise extends AbstractResource
     /**
      * Set endDate
      *
-     * @param datetime $endDate
+     * @param \Datetime $endDate
      */
-    public function setEndDate($endDate)
+    public function setEndDate(\DateTime $endDate)
     {
         $this->endDate = $endDate;
     }
@@ -483,7 +480,7 @@ class Exercise extends AbstractResource
     /**
      * Get endDate
      *
-     * @return datetime
+     * @return \Datetime
      */
     public function getEndDate()
     {

--- a/Entity/Interaction.php
+++ b/Entity/Interaction.php
@@ -2,6 +2,7 @@
 
 namespace UJM\ExoBundle\Entity;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -29,7 +30,7 @@ class Interaction
     private $type;
 
     /**
-     * @var text $invite
+     * @var string $invite
      *
      * @ORM\Column(name="invite", type="text")
      */
@@ -43,7 +44,7 @@ class Interaction
     private $ordre;
 
     /**
-     * @var text $feedBack
+     * @var string $feedBack
      *
      * @ORM\Column(name="feedback", type="text", nullable=true)
      */
@@ -54,7 +55,7 @@ class Interaction
      *
      * @ORM\Column(name="locked_expertise", type="boolean", nullable=true)
      */
-    private $lockedExpertise;
+    private $lockedExpertise = false;
 
     /**
      * @ORM\ManyToMany(targetEntity="UJM\ExoBundle\Entity\Document")
@@ -84,9 +85,8 @@ class Interaction
      */
     public function __construct()
     {
-        $this->documents = new \Doctrine\Common\Collections\ArrayCollection;
-        $this->hints = new \Doctrine\Common\Collections\ArrayCollection;
-        $this->setLockedExpertise(false);
+        $this->documents = new ArrayCollection();
+        $this->hints = new ArrayCollection();
     }
 
     /**
@@ -222,7 +222,7 @@ class Interaction
         return $this->question;
     }
 
-    public function setQuestion(\UJM\ExoBundle\Entity\Question $question)
+    public function setQuestion(Question $question)
     {
         $this->question = $question;
     }
@@ -232,7 +232,7 @@ class Interaction
         return $this->hints;
     }
 
-    public function addHint(\UJM\ExoBundle\Entity\Hint $hint)
+    public function addHint(Hint $hint)
     {
         $this->hints[] = $hint;
         //le choix est bien lié à l'entité interactionqcm, mais dans l'entité choice il faut

--- a/Entity/InteractionQCM.php
+++ b/Entity/InteractionQCM.php
@@ -2,6 +2,7 @@
 
 namespace UJM\ExoBundle\Entity;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -26,7 +27,7 @@ class InteractionQCM
      *
      * @ORM\Column(name="shuffle", type="boolean", nullable=true)
      */
-    private $shuffle;
+    private $shuffle = false;
 
     /**
      * @var float $scoreRightResponse
@@ -47,7 +48,7 @@ class InteractionQCM
      *
      * @ORM\Column(name="weight_response", type="boolean", nullable=true)
      */
-    private $weightResponse;
+    private $weightResponse = false;
 
     /**
      * @ORM\OneToMany(targetEntity="UJM\ExoBundle\Entity\Choice", mappedBy="interactionQCM", cascade={"remove"})
@@ -70,9 +71,7 @@ class InteractionQCM
      */
     public function __construct()
     {
-        $this->choices = new \Doctrine\Common\Collections\ArrayCollection;
-        $this->setShuffle(false);
-        $this->setWeightResponse(false);
+        $this->choices = new ArrayCollection();
     }
 
     /**
@@ -90,7 +89,7 @@ class InteractionQCM
         return $this->interaction;
     }
 
-    public function setInteraction(\UJM\ExoBundle\Entity\Interaction $interaction)
+    public function setInteraction(Interaction $interaction)
     {
         $this->interaction = $interaction;
     }
@@ -100,7 +99,7 @@ class InteractionQCM
         return $this->typeQCM;
     }
 
-    public function setTypeQCM(\UJM\ExoBundle\Entity\TypeQCM $typeQCM)
+    public function setTypeQCM(TypeQCM $typeQCM)
     {
         $this->typeQCM = $typeQCM;
     }
@@ -186,7 +185,7 @@ class InteractionQCM
         return $this->choices;
     }
 
-    public function addChoice(\UJM\ExoBundle\Entity\Choice $choice)
+    public function addChoice(Choice $choice)
     {
         $this->choices[] = $choice;
         //le choix est bien lié à l'entité interactionqcm, mais dans l'entité choice il faut
@@ -204,7 +203,7 @@ class InteractionQCM
         $i = 0;
         $tabShuffle = array();
         $tabFixed   = array();
-        $choices = new \Doctrine\Common\Collections\ArrayCollection;
+        $choices = new ArrayCollection();
         $choiceCount = count($this->choices);
 
         while ($i < $choiceCount) {
@@ -241,7 +240,7 @@ class InteractionQCM
     public function sortChoices()
     {
         $tab = array();
-        $choices = new \Doctrine\Common\Collections\ArrayCollection;
+        $choices = new ArrayCollection();
 
         foreach ($this->choices as $choice) {
             $tab[] = $choice->getOrdre();
@@ -262,14 +261,13 @@ class InteractionQCM
 
             $this->interaction = clone $this->interaction;
 
-            $newChoices = new \Doctrine\Common\Collections\ArrayCollection;
+            $newChoices = new ArrayCollection();
             foreach ($this->choices as $choice) {
                 $newChoice = clone $choice;
                 $newChoice->setInteractionQCM($this);
                 $newChoices->add($newChoice);
             }
             $this->choices = $newChoices;
-
         }
     }
 }

--- a/Entity/Question.php
+++ b/Entity/Question.php
@@ -2,6 +2,8 @@
 
 namespace UJM\ExoBundle\Entity;
 
+use Claroline\CoreBundle\Entity\User;
+use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -29,21 +31,21 @@ class Question
     private $title;
 
     /**
-     * @var text $description
+     * @var string $description
      *
      * @ORM\Column(name="description", type="text", nullable=true)
      */
     private $description;
 
     /**
-     * @var datetime $dateCreate
+     * @var \Datetime $dateCreate
      *
      * @ORM\Column(name="date_create", type="datetime")
      */
     private $dateCreate;
 
     /**
-     * @var datetime $dateModify
+     * @var \Datetime $dateModify
      *
      * @ORM\Column(name="date_modify", type="datetime", nullable=true)
      */
@@ -92,13 +94,16 @@ class Question
      */
     private $category;
 
-
     /**
-     * Constructs a new instance of Expertises / Documents
+     * Note: used for joins only.
+     *
+     * @ORM\OneToMany(targetEntity="ExerciseQuestion", mappedBy="question")
      */
+    private $exerciseQuestions;
+
     public function __construct()
     {
-        $this->documents = new \Doctrine\Common\Collections\ArrayCollection;
+        $this->documents = new ArrayCollection();
         $this->setLocked(false);
         $this->setModel(false);
     }
@@ -136,7 +141,7 @@ class Question
     /**
      * Set description
      *
-     * @param text $description
+     * @param string $description
      */
     public function setDescription($description)
     {
@@ -146,7 +151,7 @@ class Question
     /**
      * Get description
      *
-     * @return text
+     * @return string
      */
     public function getDescription()
     {
@@ -156,9 +161,9 @@ class Question
     /**
      * Set dateCreate
      *
-     * @param datetime $dateCreate
+     * @param \Datetime $dateCreate
      */
-    public function setDateCreate($dateCreate)
+    public function setDateCreate(\DateTime $dateCreate)
     {
         $this->dateCreate = $dateCreate;
     }
@@ -166,7 +171,7 @@ class Question
     /**
      * Get dateCreate
      *
-     * @return datetime
+     * @return \Datetime
      */
     public function getDateCreate()
     {
@@ -176,9 +181,9 @@ class Question
     /**
      * Set dateModify
      *
-     * @param datetime $dateModify
+     * @param \Datetime $dateModify
      */
-    public function setDateModify($dateModify)
+    public function setDateModify(\DateTime $dateModify)
     {
         $this->dateModify = $dateModify;
     }
@@ -186,7 +191,7 @@ class Question
     /**
      * Get dateModify
      *
-     * @return datetime
+     * @return \Datetime
      */
     public function getDateModify()
     {
@@ -234,7 +239,7 @@ class Question
         return $this->expertise;
     }
 
-    public function setExpertise(\UJM\ExoBundle\Entity\Expertise $expertise)
+    public function setExpertise(Expertise $expertise)
     {
         $this->expertise = $expertise;
     }
@@ -250,11 +255,11 @@ class Question
     }
 
     /**
-     * Add $Document
+     * Add document
      *
-     * @param UJM\ExoBundle\Entity\Document $Document
+     * @param Document $document
      */
-    public function addDocument(\UJM\ExoBundle\Entity\Document $document)
+    public function addDocument(Document $document)
     {
         $this->document[] = $document;
     }
@@ -264,7 +269,7 @@ class Question
         return $this->user;
     }
 
-    public function setUser(\Claroline\CoreBundle\Entity\User $user)
+    public function setUser(User $user)
     {
         $this->user = $user;
     }
@@ -274,7 +279,7 @@ class Question
         return $this->category;
     }
 
-    public function setCategory(\UJM\ExoBundle\Entity\Category $category)
+    public function setCategory(Category $category)
     {
         $this->category = $category;
     }

--- a/Manager/ExerciseManager.php
+++ b/Manager/ExerciseManager.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace UJM\ExoBundle\Manager;
+
+use Claroline\CoreBundle\Persistence\ObjectManager;
+use JMS\DiExtraBundle\Annotation as DI;
+use UJM\ExoBundle\Entity\Exercise;
+use UJM\ExoBundle\Entity\Interaction;
+
+/**
+ * @DI\Service("ujm.exo.exercise_manager")
+ */
+class ExerciseManager
+{
+    private $om;
+    private $interactionRepo;
+    private $interactionQcmRepo;
+
+    /**
+     * @DI\InjectParams({
+     *     "om" = @DI\Inject("claroline.persistence.object_manager")
+     * })
+     *
+     * @param ObjectManager $om
+     */
+    public function __construct(ObjectManager $om)
+    {
+        $this->om = $om;
+        $this->interactionRepo = $om->getRepository('UJMExoBundle:Interaction');
+        $this->interactionQcmRepo = $om->getRepository('UJMExoBundle:InteractionQCM');
+    }
+
+    /**
+     * @todo add user parameter...
+     *
+     * @param Exercise $exercise
+     * @return array
+     */
+    public function exportExercise(Exercise $exercise)
+    {
+        return [
+            'id' => $exercise->getId(),
+            'meta' => $this->getMetadata($exercise),
+            'steps' => $this->getSteps($exercise)
+        ];
+    }
+
+    /**
+     * @todo add allowedToCompose: isPublished && (isAdmin || startDate/endDate)
+     * @todo what about duration / nbQuestionPage ? seem unused...
+     * @todo add useEndDate ?
+     *
+     * @param Exercise $exercise
+     * @return array
+     */
+    private function getMetadata(Exercise $exercise)
+    {
+        $node = $exercise->getResourceNode();
+        $creator = $node->getCreator();
+        $authorName = sprintf('%s %s', $creator->getFirstName(), $creator->getLastName());
+
+        return [
+            'authors' => [$authorName],
+            'created' => $node->getCreationDate()->format('Y-m-d H:i:s'),
+            'title' => $exercise->getTitle(),
+            'description' => $exercise->getDescription(),
+            'start' => $exercise->getStartDate()->format('Y-m-d H:i:s'),
+            'end' => $exercise->getEndDate()->format('Y-m-d H:i:s'),
+            'isPublished' => $exercise->getpublished(),
+            'pick' => $exercise->getNbQuestion(),
+            'random' => $exercise->getShuffle(),
+            'maxAttempts' => $exercise->getMaxAttempts()
+        ];
+    }
+
+    /**
+     * @todo step id...
+     * @todo add optional question description (schema)
+     *
+     * @param Exercise $exercise
+     * @return array
+     */
+    private function getSteps(Exercise $exercise)
+    {
+        $interactions = $this->interactionRepo->findByExercise($exercise);
+
+        return array_map(function ($interaction) {
+            switch ($type = $interaction->getType()) {
+                case 'InteractionQCM':
+                    $data = $this->getQCM($interaction);
+                    $type = 'application/x.choice+json';
+                    break;
+                default:
+                    throw new \Exception("Export not implemented for {$type} type");
+            }
+
+            $step = [
+                'id' => 'todo',
+                'items' => [array_merge($data, [
+                    'id' => $interaction->getId(),
+                    'type' => $type,
+                    'title' => $interaction->getQuestion()->getTitle(),
+                    'hints' => ''
+                ])]
+            ];
+
+            if ($interaction->getFeedback()) {
+                $step['items'][0]['feedback'] = $interaction->getFeedback();
+            }
+
+            if (count($hints = $interaction->getHints()->toArray()) > 0) {
+                $step['items'][0]['hints'] = array_map(function ($hint) {
+                    return [
+                        'id' => $hint->getId(),
+                        'text' => $hint->getValue(),
+                        'penalty' => $hint->getPenalty()
+                    ];
+                }, $hints);
+            }
+
+            return $step;
+        }, $interactions);
+    }
+
+    /**
+     * @todo get real "multiple" value
+     * @todo add solutions property
+     * @todo check order of choices
+     * @todo weight ?
+     *
+     * @param Interaction $interaction
+     * @return array
+     */
+    private function getQCM(Interaction $interaction)
+    {
+        $qcm = $this->interactionQcmRepo->findOneBy(['interaction' => $interaction]);
+
+        return [
+            'multiple' => false,
+            'random' => $qcm->getShuffle(),
+            'choices' => array_map(function ($choice) {
+                return [
+                    'id' => $choice->getId(),
+                    'type' => 'text/html',
+                    'data' => $choice->getLabel()
+                ];
+            }, $qcm->getChoices()->toArray()),
+        ];
+    }
+}

--- a/Repository/InteractionQCMRepository.php
+++ b/Repository/InteractionQCMRepository.php
@@ -12,7 +12,6 @@ use Doctrine\ORM\EntityRepository;
  */
 class InteractionQCMRepository extends EntityRepository
 {
-
     /**
      * Get InteractionQCM linked with an interaction
      *

--- a/Repository/InteractionRepository.php
+++ b/Repository/InteractionRepository.php
@@ -3,6 +3,8 @@
 namespace UJM\ExoBundle\Repository;
 
 use Doctrine\ORM\EntityRepository;
+use UJM\ExoBundle\Entity\Exercise;
+use UJM\ExoBundle\Entity\Interaction;
 
 /**
  * InteractionRepository
@@ -77,6 +79,26 @@ class InteractionRepository extends EntityRepository
             ->addOrderBy('q.title', 'ASC');
 
         return $qb->getQuery()->getResult();
+    }
+
+    /**
+     * Returns all the interactions linked to a given exercise.
+     *
+     * @param Exercise $exercise
+     * @return Interaction[]
+     */
+    public function findByExercise(Exercise $exercise)
+    {
+        return $this->createQueryBuilder('i')
+            ->select('i')
+            ->join('i.question', 'q')
+            ->join('q.exerciseQuestions', 'eq')
+            ->join('eq.exercise', 'e')
+            ->where('e = :exercise')
+            ->orderBy('eq.ordre')
+            ->setParameter(':exercise', $exercise)
+            ->getQuery()
+            ->getResult();
     }
 
     /**

--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -64,3 +64,8 @@ sequence_step_questions:
     resource: "@UJMExoBundle/Controller/Sequence/StepQuestionController.php"
     type: annotation
     prefix: /step-question
+
+api_exercise:
+    resource: "@UJMExoBundle/Controller/Api/ExerciseController.php"
+    type: annotation
+    prefix: /api

--- a/Tests/Controller/Api/ExerciseControllerTest.php
+++ b/Tests/Controller/Api/ExerciseControllerTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace UJM\ExoBundle\Tests\Controller\Api;
+
+use Claroline\CoreBundle\Library\Testing\TransactionalTestCase;
+
+class ExerciseControllerTest extends TransactionalTestCase
+{
+    public function test()
+    {
+        $this->markTestSkipped('Not implemented');
+
+        $this->client->request('GET', '/exercise/api/test');
+        $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $this->assertEquals('TEST', $this->client->getResponse()->getContent());
+    }
+}

--- a/Tests/Manager/ExerciseManagerTest.php
+++ b/Tests/Manager/ExerciseManagerTest.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace UJM\ExoBundle\Manager;
+
+class ExerciseManagerTest extends \PHPUnit_Framework_TestCase
+{
+    public function test()
+    {
+        $this->markTestSkipped('Not implemented');
+    }
+}

--- a/Tests/Repository/InteractionRepositoryTest.php
+++ b/Tests/Repository/InteractionRepositoryTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace UJM\ExoBundle\Repository;
+
+use Claroline\CoreBundle\Library\Testing\TransactionalTestCase;
+use UJM\ExoBundle\Entity\Exercise;
+use UJM\ExoBundle\Entity\ExerciseQuestion;
+use UJM\ExoBundle\Entity\Interaction;
+use UJM\ExoBundle\Entity\InteractionQCM;
+use UJM\ExoBundle\Entity\Question;
+
+class InteractionRepositoryTest extends TransactionalTestCase
+{
+    private $om;
+    private $repo;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->om = $this->client->getContainer()->get('claroline.persistence.object_manager');
+        $this->repo = $this->om->getRepository('UJMExoBundle:Interaction');
+    }
+
+    public function testFindByExercise()
+    {
+        $q1 = $this->persistQcmQuestion('qcm1');
+        $q2 = $this->persistQcmQuestion('qcm2');
+        $q3 = $this->persistQcmQuestion('qcm3'); // extra
+        $e1 = $this->persistExercise('ex1', [$q1, $q2]);
+        $this->om->flush();
+
+        $interactions = $this->repo->findByExercise($e1);
+        $this->assertEquals(2, count($interactions));
+        $this->assertEquals($q1, $interactions[0]->getQuestion());
+        $this->assertEquals($q2, $interactions[1]->getQuestion());
+    }
+
+    private function persistQcmQuestion($title, array $choices = [])
+    {
+        $question = new Question();
+        $question->setTitle($title);
+        $question->setDateCreate(new \DateTime());
+
+        $interaction = new Interaction();
+        $interaction->setType('InteractionQCM');
+        $interaction->setQuestion($question);
+        $interaction->setInvite('Invite...');
+
+        $interactionQcm = new InteractionQCM();
+        $interactionQcm->setInteraction($interaction);
+
+        $this->om->persist($interactionQcm);
+        $this->om->persist($interaction);
+        $this->om->persist($question);
+
+        return $question;
+    }
+
+    private function persistExercise($title, array $questions = [])
+    {
+        $exercise = new Exercise();
+        $exercise->setTitle($title);
+        $exercise->setNbQuestion(0);
+        $exercise->setNbQuestionPage(0);
+        $exercise->setDateCreate(new \DateTime());
+        $exercise->setStartDate(new \DateTime());
+        $exercise->setEndDate(new \DateTime());
+        $exercise->setUseDateEnd(false);
+        $exercise->setDuration(0);
+        $exercise->setMaxAttempts(0);
+        $exercise->setCorrectionMode(0);
+        $exercise->setMarkMode(0);
+        $exercise->setPublished(true);
+
+        for ($i = 0, $max = count($questions); $i < $max; ++$i) {
+            $link = new ExerciseQuestion($exercise, $questions[$i]);
+            $link->setOrdre($i);
+            $this->om->persist($link);
+        }
+
+        $this->om->persist($exercise);
+
+        return $exercise;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,9 @@
         "innova/angular-ui-sortable-bundle" : "~5.0",
         "innova/angular-ui-pageslide-bundle" : "~5.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "~4.6"
+    },
     "autoload": {
         "psr-0": { "UJM\\ExoBundle": "" }
     },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit
+    backupGlobals               = "false"
+    backupStaticAttributes      = "false"
+    colors                      = "true"
+    convertErrorsToExceptions   = "true"
+    convertNoticesToExceptions  = "true"
+    convertWarningsToExceptions = "true"
+    processIsolation            = "false"
+    stopOnFailure               = "false"
+    syntaxCheck                 = "false"
+    bootstrap                   = "../../../../../app/bootstrap.php.cache" >
+
+    <php>
+        <server name="KERNEL_DIR" value="../../../../../app/" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Exo bundle test suite">
+            <directory>Tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>.</directory>
+            <exclude>
+                <directory>Migrations</directory>
+                <directory>Resources</directory>
+                <directory>Tests</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+
+</phpunit>


### PR DESCRIPTION
Lot of stuff is missing, but `/exercise/api/exercises/{id}` will return the JSON representation of an exercise (currently limited to choice questions). 