### PR TITLE
Switch to resource node date access control

### DIFF
--- a/Controller/ExerciseController.php
+++ b/Controller/ExerciseController.php
@@ -133,7 +133,6 @@ class ExerciseController extends Controller
         $isAllowedToOpen = $exerciseSer->allowToOpen($exercise);
         $isAllowedToCompose = $isExoAdmin
             || $isAllowedToOpen
-            && $exerciseSer->controlDate($isExoAdmin, $exercise)
             && $exerciseSer->controlMaxAttemps($exercise, $userId, $isExoAdmin);
 
         if ($isAllowedToOpen && $userId !== 'anonymous') {
@@ -638,9 +637,7 @@ class ExerciseController extends Controller
 
         $workspace = $exercise->getResourceNode()->getWorkspace();
 
-        if ( ($exerciseSer->controlDate($exoAdmin, $exercise) === true)
-             && ( ($exercise->getResourceNode()->isPublished() === true) || ($exoAdmin === true) )
-           ) {
+        if ($exoAdmin || $exercise->getResourceNode()->isPublished()) {
             $session = $this->getRequest()->getSession();
 
             if ($uid != 'anonymous') {

--- a/Controller/PaperController.php
+++ b/Controller/PaperController.php
@@ -93,9 +93,8 @@ class PaperController extends Controller
             $arrayMarkPapers[$p->getId()] = $this->container->get('ujm.exo_paper')->getInfosPaper($p);
         }
 
-        if (($exerciseSer->controlDate($exoAdmin, $exercise) === true)
-            && ($exerciseSer->controlMaxAttemps($exercise, $user->getId(), $exoAdmin) === true)
-            && ( ($exercise->getResourceNode()->isPublished() === true) || ($exoAdmin == 1) )
+        if ($exerciseSer->controlMaxAttemps($exercise, $user->getId(), $exoAdmin) === true
+            && ($exercise->getResourceNode()->isPublished() || $exoAdmin == 1 )
         ) {
             $retryButton = true;
         }

--- a/Entity/Exercise.php
+++ b/Entity/Exercise.php
@@ -2,9 +2,9 @@
 
 namespace UJM\ExoBundle\Entity;
 
+use Claroline\CoreBundle\Entity\Resource\AbstractResource;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
-use Claroline\CoreBundle\Entity\Resource\AbstractResource;
 
 /**
  * UJM\ExoBundle\Entity\Exercise
@@ -48,13 +48,6 @@ class Exercise extends AbstractResource
      * @ORM\Column(name="keepSameQuestion", type="boolean", nullable=true)
      */
     private $keepSameQuestion;
-
-    /**
-     * @var \Datetime $dateCreate
-     *
-     * @ORM\Column(name="date_create", type="datetime")
-     */
-    private $dateCreate;
 
     /**
      * @var integer $duration
@@ -173,7 +166,7 @@ class Exercise extends AbstractResource
         $this->groupes = new \Doctrine\Common\Collections\ArrayCollection;
 
         // todo: remove these default values (coming from listener#createForm)
-        $this->dateCreate = new \DateTime();
+
         $this->startDate = new \DateTime();
         $this->endDate = new \DateTime();
         $this->dateCorrection = new \DateTime();
@@ -283,26 +276,6 @@ class Exercise extends AbstractResource
     public function getKeepSameQuestion()
     {
         return $this->keepSameQuestion;
-    }
-
-    /**
-     * Set dateCreate
-     *
-     * @param \Datetime $dateCreate
-     */
-    public function setDateCreate(\DateTime $dateCreate)
-    {
-        $this->dateCreate = $dateCreate;
-    }
-
-    /**
-     * Get dateCreate
-     *
-     * @return \Datetime
-     */
-    public function getDateCreate()
-    {
-        return $this->dateCreate;
     }
 
     /**

--- a/Entity/Exercise.php
+++ b/Entity/Exercise.php
@@ -103,27 +103,6 @@ class Exercise extends AbstractResource
     private $markMode = '1';
 
     /**
-     * @var \Datetime $startDate
-     *
-     * @ORM\Column(name="start_date", type="datetime")
-     */
-    private $startDate;
-
-    /**
-     * @var boolean $useDateEnd
-     *
-     * @ORM\Column(name="use_date_end", type="boolean", nullable=true)
-     */
-    private $useDateEnd;
-
-    /**
-     * @var \Datetime $end_date
-     *
-     * @ORM\Column(name="end_date", type="datetime", nullable=true)
-     */
-    private $endDate;
-
-    /**
      * @var boolean $dispButtonInterrupt
      *
      * @ORM\Column(name="disp_button_interrupt", type="boolean", nullable=true)
@@ -164,11 +143,6 @@ class Exercise extends AbstractResource
     public function __construct()
     {
         $this->groupes = new \Doctrine\Common\Collections\ArrayCollection;
-
-        // todo: remove these default values (coming from listener#createForm)
-
-        $this->startDate = new \DateTime();
-        $this->endDate = new \DateTime();
         $this->dateCorrection = new \DateTime();
     }
 
@@ -414,64 +388,6 @@ class Exercise extends AbstractResource
     public function getMarkMode()
     {
         return $this->markMode;
-    }
-
-    /**
-     * Set startDate
-     *
-     * @param \DateTime $startDate
-     */
-    public function setStartDate(\DateTime $startDate)
-    {
-        $this->startDate = $startDate;
-    }
-
-    /**
-     * Get startDate
-     *
-     * @return \Datetime
-     */
-    public function getStartDate()
-    {
-        return $this->startDate;
-    }
-
-     /**
-     * Set useDateEnd
-     *
-     * @param boolean $useDateEnd
-     */
-    public function setUseDateEnd($useDateEnd)
-    {
-        $this->useDateEnd = $useDateEnd;
-    }
-
-    /**
-     * Get useDateEnd
-     */
-    public function getUseDateEnd()
-    {
-        return $this->useDateEnd;
-    }
-
-    /**
-     * Set endDate
-     *
-     * @param \Datetime $endDate
-     */
-    public function setEndDate(\DateTime $endDate)
-    {
-        $this->endDate = $endDate;
-    }
-
-    /**
-     * Get endDate
-     *
-     * @return \Datetime
-     */
-    public function getEndDate()
-    {
-        return $this->endDate;
     }
 
     /**

--- a/Form/ExerciseHandler.php
+++ b/Form/ExerciseHandler.php
@@ -71,8 +71,6 @@ class ExerciseHandler
      */
     private function onSuccess(Exercise $exercise)
     {
-        // \ pour instancier un objet du namespace global et non pas de l'actuel
-        $exercise->setDateCreate(new \Datetime());
         $exercise->setNbQuestionPage(1);
         $this->em->persist($exercise);
         $this->em->flush();

--- a/Form/ExerciseType.php
+++ b/Form/ExerciseType.php
@@ -89,24 +89,6 @@ class ExerciseType extends AbstractType
                     '2' => 'at_the_end_of_assessment'
                 ]
             ])
-            ->add('start_date', 'datetime', [
-                'widget' => 'single_text',
-                'input' => 'datetime',
-                'format' => 'dd/MM/yyyy H:mm:ss',
-                'attr' => ['data-format' => 'dd/MM/yyyy H:mm:ss'],
-                'label' => 'start_date',
-            ])
-            ->add('useDateEnd', 'checkbox', [
-                'required' => false,
-                'label' => 'use_date_end'
-            ])
-            ->add('end_date', 'datetime', [
-                'widget' => 'single_text',
-                'input' => 'datetime',
-                'format' => 'dd/MM/yyyy H:mm:ss',
-                'attr' => ['data-format' => 'dd/MM/yyyy H:mm:ss'],
-                'label' => 'end_date',
-            ])
             ->add('dispButtonInterrupt', 'checkbox', [
                 'required' => false,
                 'label' => 'test_exit'

--- a/Installation/AdditionalInstaller.php
+++ b/Installation/AdditionalInstaller.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace UJM\ExoBundle\Installation;
+
+use Claroline\InstallationBundle\Additional\AdditionalInstaller as BaseInstaller;
+
+class AdditionalInstaller extends BaseInstaller
+{
+    public function preUpdate($currentVersion, $targetVersion)
+    {
+        if (version_compare($currentVersion, '6.0.0', '<=')) {
+            $this->migrateDateData();
+        }
+    }
+
+    private function migrateDateData()
+    {
+        $conn = $this->container->get('doctrine.dbal.default_connection');
+
+        if (!$conn->getSchemaManager()->listTableDetails('ujm_exercise')->hasColumn('start_date')) {
+            return; // migration has already been executed
+        }
+
+        $this->log('Moving date data from ujm_exercise to claro_resource_node');
+
+        $startQuery = '
+            UPDATE claro_resource_node AS node
+            JOIN ujm_exercise AS exo
+            ON node.id = exo.resourceNode_id
+            SET node.accessible_from = exo.start_date
+            WHERE node.accessible_from IS NULL
+            AND exo.start_date IS NOT NULL
+        ';
+        $endQuery = '
+            UPDATE claro_resource_node AS node
+            JOIN ujm_exercise AS exo
+            ON node.id = exo.resourceNode_id
+            SET node.accessible_until = exo.end_date
+            WHERE node.accessible_until IS NULL
+            AND exo.start_date IS NOT NULL
+            AND exo.use_date_end = 1
+        ';
+
+        $conn->exec($startQuery);
+        $conn->exec($endQuery);
+    }
+}

--- a/Listener/ExerciseListener.php
+++ b/Listener/ExerciseListener.php
@@ -173,19 +173,17 @@ class ExerciseListener
     public function onCopy(CopyResourceEvent $event)
     {
         $em = $this->container->get('doctrine.orm.entity_manager');
-        $resource = $event->getResource();
 
-        $exerciseToCopy = $em->getRepository('UJMExoBundle:Exercise')->find($resource->getId());
+        $exerciseToCopy = $event->getResource();
         $listQuestionsExoToCopy = $em->getRepository('UJMExoBundle:ExerciseQuestion')
-                                     ->findBy(array('exercise' => $exerciseToCopy->getId()));
+            ->findBy(['exercise' => $exerciseToCopy->getId()]);
 
         $newExercise = new Exercise();
-        $newExercise->setName($resource->getName());
+        $newExercise->setName($exerciseToCopy->getName());
         $newExercise->setTitle($exerciseToCopy->getTitle());
         $newExercise->setDescription($exerciseToCopy->getDescription());
         $newExercise->setShuffle($exerciseToCopy->getShuffle());
         $newExercise->setNbQuestion($exerciseToCopy->getNbQuestion());
-        $newExercise->setDateCreate($exerciseToCopy->getDateCreate());
         $newExercise->setDuration($exerciseToCopy->getDuration());
         $newExercise->setNbQuestionPage($exerciseToCopy->getNbQuestionPage());
         $newExercise->setDoprint($exerciseToCopy->getDoprint());

--- a/Listener/ExerciseListener.php
+++ b/Listener/ExerciseListener.php
@@ -191,9 +191,6 @@ class ExerciseListener
         $newExercise->setCorrectionMode($exerciseToCopy->getCorrectionMode());
         $newExercise->setDateCorrection($exerciseToCopy->getDateCorrection());
         $newExercise->setMarkMode($exerciseToCopy->getMarkMode());
-        $newExercise->setStartDate($exerciseToCopy->getStartDate());
-        $newExercise->setUseDateEnd($exerciseToCopy->getUseDateEnd());
-        $newExercise->setEndDate($exerciseToCopy->getEndDate());
         $newExercise->setDispButtonInterrupt($exerciseToCopy->getDispButtonInterrupt());
         $newExercise->setLockAttempt($exerciseToCopy->getLockAttempt());
 

--- a/Manager/ApiManager.php
+++ b/Manager/ApiManager.php
@@ -46,9 +46,7 @@ class ApiManager
     }
 
     /**
-     * @todo add allowedToCompose: isPublished && (isAdmin || startDate/endDate)
-     * @todo what about duration / nbQuestionPage ? seem unused...
-     * @todo add useEndDate ?
+     * @todo add duration
      *
      * @param Exercise $exercise
      * @return array
@@ -64,8 +62,6 @@ class ApiManager
             'created' => $node->getCreationDate()->format('Y-m-d H:i:s'),
             'title' => $exercise->getTitle(),
             'description' => $exercise->getDescription(),
-            'start' => $exercise->getStartDate()->format('Y-m-d H:i:s'),
-            'end' => $exercise->getEndDate()->format('Y-m-d H:i:s'),
             'pick' => $exercise->getNbQuestion(),
             'random' => $exercise->getShuffle(),
             'maxAttempts' => $exercise->getMaxAttempts()

--- a/Migrations/pdo_mysql/Version20150907115314.php
+++ b/Migrations/pdo_mysql/Version20150907115314.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace UJM\ExoBundle\Migrations\pdo_mysql;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated migration based on mapping information: modify it with caution
+ *
+ * Generation date: 2015/09/07 11:53:16
+ */
+class Version20150907115314 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        $this->addSql("
+            ALTER TABLE ujm_exercise 
+            DROP date_create
+        ");
+    }
+
+    public function down(Schema $schema)
+    {
+        $this->addSql("
+            ALTER TABLE ujm_exercise 
+            ADD date_create DATETIME NOT NULL
+        ");
+    }
+}

--- a/Migrations/pdo_mysql/Version20150907143418.php
+++ b/Migrations/pdo_mysql/Version20150907143418.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace UJM\ExoBundle\Migrations\pdo_mysql;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated migration based on mapping information: modify it with caution
+ *
+ * Generation date: 2015/09/07 02:34:19
+ */
+class Version20150907143418 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        $this->addSql("
+            ALTER TABLE ujm_exercise 
+            DROP start_date, 
+            DROP use_date_end, 
+            DROP end_date
+        ");
+    }
+
+    public function down(Schema $schema)
+    {
+        $this->addSql("
+            ALTER TABLE ujm_exercise 
+            ADD start_date DATETIME NOT NULL, 
+            ADD use_date_end TINYINT(1) DEFAULT NULL, 
+            ADD end_date DATETIME DEFAULT NULL
+        ");
+    }
+}

--- a/Resources/translations/ujm_exo.en.yml
+++ b/Resources/translations/ujm_exo.en.yml
@@ -330,7 +330,6 @@ type_question: Question type
 unpublish: Unpublish
 upload: Upload
 uploading: Uploading
-use_date_end: Use end date
 user: User
 users: Users
 

--- a/Resources/translations/ujm_exo.fr.yml
+++ b/Resources/translations/ujm_exo.fr.yml
@@ -331,7 +331,6 @@ type_question: Type de la question
 unpublish: Dépublier
 upload: Télécharger
 uploading: Chargement en cours
-use_date_end: Utiliser une date de fin
 user: Utilisateur
 users: Utilisateurs
 

--- a/Resources/views/Exercise/edit.html.twig
+++ b/Resources/views/Exercise/edit.html.twig
@@ -41,26 +41,6 @@
                     <div class="panel-body">
                         {{ form_row(edit_form.title) }}
                         {{ form_row(edit_form.description) }}
-                        <div class="form-group row date picker">
-                            {{ form_label(edit_form.start_date) }}
-                            <div class="col-md-9">
-                                <div class="input-group">
-                                    {{ form_widget(edit_form.start_date) }}
-                                </div>
-                            </div>
-                        </div>
-                        <div class="form-group row">
-                            {{ form_label(edit_form.useDateEnd) }}
-                            <div class="col-md-9">{{ form_widget(edit_form.useDateEnd) }}</div>
-                        </div>
-                        <div class="form-group row date picker" id="dateEnd" style="display: none;">
-                            {{ form_label(edit_form.end_date) }}
-                            <div class="col-md-9">
-                                <div class="input-group">
-                                    {{ form_widget(edit_form.end_date) }}
-                                </div>
-                            </div>
-                        </div>
                     </div>
                 </div>
                 {#--------------------------------------------- Questions -----------------------------------------------#}
@@ -150,20 +130,8 @@
             $('#ujm_exobundle_exercisetype_duration').attr("disabled", true);
             $('#ujm_exobundle_exercisetype_lockAttempt').attr("disabled", true);
 
-            if($("#ujm_exobundle_exercisetype_useDateEnd").attr("checked")) {
-                $('#dateEnd').css({"display" : "block"});
-            }
-
             if ($("*[id$='_exercisetype_correctionMode']").val() == 3) {
                 $('#CorrectionMode').css({"display" : "block"});
-            }
-        });
-
-        $("#ujm_exobundle_exercisetype_useDateEnd").change(function () {
-            if(this.checked) {
-                $('#dateEnd').css({"display" : "block"});
-            } else {
-                $('#dateEnd').css({"display" : "none"});
             }
         });
 

--- a/Resources/views/Exercise/show.html.twig
+++ b/Resources/views/Exercise/show.html.twig
@@ -65,24 +65,24 @@
                         </tr>
                         <tr>
                             <th class="classic">{{ 'start_date' | trans({}, 'ujm_exo') }}</th>
-                            <td class="classic">{{ exercise.startdate|date('d/m/Y \\- H\\hi\\ms\\s') }}</td>
-                        </tr>
-                        <tr>
-                            <th class="classic">{{ 'use_date_end' | trans({}, 'ujm_exo') }}</th>
                             <td class="classic">
-                                {% if exercise.useDateEnd == 0 %}
-                                    <i class="fa fa-times-circle"></i>
+                                {% if resource.getAccessibleFrom() %}
+                                    {{ resource.getAccessibleFrom()|date('d/m/Y \\- H\\hi\\ms\\s') }}
                                 {% else %}
-                                    <i class="fa fa-check-circle"></i>
+                                    -
                                 {% endif %}
                             </td>
                         </tr>
-                        {% if exercise.useDateEnd != 0 %}
-                            <tr>
-                                <th class="classic">{{ 'end_date' | trans({}, 'ujm_exo') }}</th>
-                                <td class="classic">{{ exercise.enddate|date('d/m/Y \\- H\\hi\\ms\\s') }}</td>
-                            </tr>
-                        {% endif %}
+                        <tr>
+                            <th class="classic">{{ 'end_date' | trans({}, 'ujm_exo') }}</th>
+                            <td class="classic">
+                                {% if resource.getAccessibleUntil() %}
+                                    {{ resource.getAccessibleUntil()|date('d/m/Y \\- H\\hi\\ms\\s') }}
+                                {% else %}
+                                    -
+                                {% endif %}
+                            </td>
+                        </tr>
 
                         {% if is_granted('ADMINISTRATE', exercise) %}
                             <tr class="hiddencells">
@@ -105,7 +105,7 @@
                                     {% endif %}
                                 </td>
                             </tr>
-                           {#---not operational---#}
+                            {#---not operational---#}
                                 {#<tr class="hiddencells">
                                 <th class="classic">{{ 'keep_same_question' | trans({}, 'ujm_exo') }}</th>
                                 <td class="classic">

--- a/Resources/views/Exercise/show.html.twig
+++ b/Resources/views/Exercise/show.html.twig
@@ -114,11 +114,11 @@
                                     {% else %}
                                         <i class="fa fa-check-circle"></i>
                                     {% endif %}
-                                </td> #}
-                            </tr>
+                                </td>
+                            </tr>#}
                             <tr class="hiddencells">
                                 <th class="classic">{{ 'creation_date' | trans({}, 'ujm_exo') }}</th>
-                                <td class="classic">{{ exercise.dateCreate|date('d/m/Y \\- H\\hi\\ms\\s') }}</td>
+                                <td class="classic">{{ resource.getCreationDate()|date('d/m/Y \\- H\\hi\\ms\\s') }}</td>
                             </tr>
                             <tr style="display: none;">
                                 <th class="classic">{{ 'duration' | trans({}, 'ujm_exo') }}</th>

--- a/Services/classes/ExerciseServices.php
+++ b/Services/classes/ExerciseServices.php
@@ -226,30 +226,6 @@ class ExerciseServices
     }
 
     /**
-     * The user must be registered (and the dates must be good or the user must to be admin for the exercise)
-     *
-     * @access public
-     *
-     * @param boolean $exoAdmin
-     * @param \UJM\ExoBundle\Entity\Exercise $exercise
-     *
-     * @return boolean
-     */
-    public function controlDate($exoAdmin, $exercise)
-    {
-        if (
-            ((($exercise->getStartDate()->format('Y-m-d H:i:s') <= date('Y-m-d H:i:s'))
-            && (($exercise->getUseDateEnd() == 0)
-            || ($exercise->getEndDate()->format('Y-m-d H:i:s') >= date('Y-m-d H:i:s'))))
-            || ($exoAdmin === true))
-        ) {
-            return true;
-        } else {
-            return false;
-        }
-    }
-
-    /**
      * Add an Interaction in an exercise if created from an exercise
      *
      * @access public

--- a/Tests/Form/ExerciseTypeTest.php
+++ b/Tests/Form/ExerciseTypeTest.php
@@ -56,9 +56,7 @@ class ExerciseTypeTest extends TypeTestCase
             'title' => 'Ex 1',
             'description' => 'Desc...',
             'duration' => '3600',
-            'dateCorrection' => '2012-01-12',
-            'start_date' => '2012-01-10',
-            'end_date' => '2012-01-11'
+            'lockAttempt' => '1'
         ];
 
         $form = $this->factory->create(new ExerciseType(), new Exercise());

--- a/Tests/Form/ExerciseTypeTest.php
+++ b/Tests/Form/ExerciseTypeTest.php
@@ -56,7 +56,8 @@ class ExerciseTypeTest extends TypeTestCase
             'title' => 'Ex 1',
             'description' => 'Desc...',
             'duration' => '3600',
-            'lockAttempt' => '1'
+            'lockAttempt' => '1',
+            'dateCorrection' => '2015-02-03'
         ];
 
         $form = $this->factory->create(new ExerciseType(), new Exercise());

--- a/Tests/Repository/InteractionRepositoryTest.php
+++ b/Tests/Repository/InteractionRepositoryTest.php
@@ -60,7 +60,6 @@ class InteractionRepositoryTest extends TransactionalTestCase
     {
         $exercise = new Exercise();
         $exercise->setTitle($title);
-        $exercise->setUseDateEnd(false);
 
         for ($i = 0, $max = count($questions); $i < $max; ++$i) {
             $link = new ExerciseQuestion($exercise, $questions[$i]);

--- a/Transfert/ExoImporter.php
+++ b/Transfert/ExoImporter.php
@@ -175,7 +175,6 @@ class ExoImporter extends Importer implements ConfigurationInterface
     private function createExo($title, $user) {
         $newExercise = new Exercise();
         $newExercise->setTitle($title);
-        $newExercise->setDateCreate(new \Datetime());
         $newExercise->setNbQuestionPage(1);
         $newExercise->setNbQuestion(0);
         $newExercise->setDuration(0);

--- a/Transfert/ExoImporter.php
+++ b/Transfert/ExoImporter.php
@@ -179,8 +179,6 @@ class ExoImporter extends Importer implements ConfigurationInterface
         $newExercise->setNbQuestion(0);
         $newExercise->setDuration(0);
         $newExercise->setMaxAttempts(0);
-        $newExercise->setStartDate(new \Datetime());
-        $newExercise->setEndDate(new \Datetime());
         $newExercise->setDateCorrection(new \Datetime());
         $newExercise->setCorrectionMode('1');
         $newExercise->setMarkMode('1');

--- a/UJMExoBundle.php
+++ b/UJMExoBundle.php
@@ -4,27 +4,32 @@ namespace UJM\ExoBundle;
 
 use Claroline\CoreBundle\Library\PluginBundle;
 use Claroline\KernelBundle\Bundle\ConfigurationBuilder;
+use Claroline\KernelBundle\Bundle\ConfigurationProviderInterface;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+use UJM\ExoBundle\Installation\AdditionalInstaller;
 
-class UJMExoBundle extends PluginBundle {
-
-    public function getContainerExtension() {
+class UJMExoBundle extends PluginBundle implements ConfigurationProviderInterface
+{
+    public function getContainerExtension()
+    {
         return new DependencyInjection\UJMExoExtension();
     }
 
-    public function getConfiguration($environment) {
+    public function getConfiguration($environment)
+    {
         $config = new ConfigurationBuilder();
 
         return $config->addRoutingResource(__DIR__ . '/Resources/config/routing.yml', null, 'exercise');
     }
 
-    public function getRequiredFixturesDirectory($environment) {
+    public function getRequiredFixturesDirectory($environment)
+    {
         return 'DataFixtures';
     }
 
-    public function suggestConfigurationFor(Bundle $bundle, $environment) {
-        $bundleClass = get_class($bundle);
-        $config = new ConfigurationBuilder();
-        $emptyConfigs = array(
+    public function suggestConfigurationFor(Bundle $bundle, $environment)
+    {
+        $emptyConfigs = [
             'Innova\AngularJSBundle\InnovaAngularJSBundle',
             'Innova\AngularUIBootstrapBundle\InnovaAngularUIBootstrapBundle',
             'Innova\AngularUITranslationBundle\InnovaAngularUITranslationBundle',
@@ -32,11 +37,17 @@ class UJMExoBundle extends PluginBundle {
             'Innova\AngularUITinyMCEBundle\InnovaAngularUITinyMCEBundle',
             'Innova\AngularUIPageslideBundle\InnovaAngularUIPageslideBundle',
             'Innova\AngularUISortableBundle\AngularUISortableBundle',
-        );
-        if (in_array($bundleClass, $emptyConfigs)) {
-            return $config;
+        ];
+
+        if (in_array(get_class($bundle), $emptyConfigs)) {
+            return new ConfigurationBuilder();
         }
+
         return false;
     }
 
+    public function getAdditionalInstaller()
+    {
+        return new AdditionalInstaller();
+    }
 }


### PR DESCRIPTION
Closes #47. Additionally, uses default resource node creation date instead of `Exercise#dateCreate`.