### PR TITLE
Update ExerciseListener.php

### DIFF
--- a/Listener/ExerciseListener.php
+++ b/Listener/ExerciseListener.php
@@ -160,7 +160,7 @@ class ExerciseListener extends ContainerAware
 
     public function onCopy(CopyResourceEvent $event)
     {
-        $em = $this->container->get('doctrine.orm.entity_manager');
+        $em = $this->container->get('claroline.persistence.object_manager');
         $resource = $event->getResource();
 
         $exerciseToCopy = $em->getRepository('UJMExoBundle:Exercise')->find($resource->getId());


### PR DESCRIPTION
This should speed up the exercice copy by a lot when claroline is doing intensive database insertions ;).
In general, I recommand you to use our object manager because we optimized large database operations around it.