### PR TITLE
Update ExerciseListener.php

### DIFF
--- a/Listener/ExerciseListener.php
+++ b/Listener/ExerciseListener.php
@@ -97,7 +97,7 @@ class ExerciseListener extends ContainerAware
 
     public function onDelete(DeleteResourceEvent $event)
     {
-        $em = $this->container->get('doctrine.orm.entity_manager');
+        $em = $this->container->get('claroline.persistence.object_manager');
 
         $papers = $em->getRepository('UJMExoBundle:Paper')
             ->findOneBy(array(


### PR DESCRIPTION
If you don't use the claroline manager, dql transactions won't work (in this case, we can't remove workspaces containing exercices).