### PR TITLE
Fixing delete.

### DIFF
--- a/Entity/Paper.php
+++ b/Entity/Paper.php
@@ -77,6 +77,7 @@ class Paper
 
     /**
      * @ORM\ManyToOne(targetEntity="UJM\ExoBundle\Entity\Exercise")
+     * @ORM\JoinColumn(onDelete="SET NULL", nullable=true)
      */
     private $exercise;
 

--- a/Listener/ExerciseListener.php
+++ b/Listener/ExerciseListener.php
@@ -97,7 +97,7 @@ class ExerciseListener extends ContainerAware
 
     public function onDelete(DeleteResourceEvent $event)
     {
-        $em = $this->container->get('doctrine.orm.entity_manager');
+        $em = $this->container->get('claroline.persistence.object_manager');
 
         $papers = $em->getRepository('UJMExoBundle:Paper')
             ->findOneBy(array(
@@ -105,46 +105,29 @@ class ExerciseListener extends ContainerAware
                 )
             );
 
-        if (count($papers) == 0) {
-
-             $eqs = $em->getRepository('UJMExoBundle:ExerciseQuestion')
-                ->findBy(array(
-                    'exercise' => $event->getResource()->getId()
-                    )
-                );
-
-            foreach ($eqs as $eq) {
-                $em->remove($eq);
-            }
-
-            $subscriptions = $em->getRepository('UJMExoBundle:Subscription')
-                ->findBy(array(
-                    'exercise' => $event->getResource()->getId()
-                    )
-                );
-
-            foreach ($subscriptions as $subscription) {
-                $em->remove($subscription);
-            }
-
-            $em->flush();
-
-            $em->remove($event->getResource());
-
-        } else {
-
-            $exercise = $em->getRepository('UJMExoBundle:Exercise')->find($event->getResource()->getId());
-            $resourceNode = $em->getRepository('ClarolineCoreBundle:Resource\ResourceNode')->find(
-                $exercise->getResourceNode()->getId()
+        $eqs = $em->getRepository('UJMExoBundle:ExerciseQuestion')
+            ->findBy(array(
+                'exercise' => $event->getResource()->getId()
+                )
             );
 
-            $em->remove($resourceNode);
-
-            $exercise->archiveExercise();
-            $em->persist($exercise);
-            $em->flush();
-            exit();
+        foreach ($eqs as $eq) {
+            $em->remove($eq);
         }
+
+        $subscriptions = $em->getRepository('UJMExoBundle:Subscription')
+            ->findBy(array(
+                'exercise' => $event->getResource()->getId()
+                )
+            );
+
+        foreach ($subscriptions as $subscription) {
+            $em->remove($subscription);
+        }
+
+        $em->flush();
+
+        $em->remove($event->getResource());
 
         $event->stopPropagation();
     }

--- a/Migrations/pdo_mysql/Version20151123143814.php
+++ b/Migrations/pdo_mysql/Version20151123143814.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace UJM\ExoBundle\Migrations\pdo_mysql;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated migration based on mapping information: modify it with caution
+ *
+ * Generation date: 2015/11/23 02:38:15
+ */
+class Version20151123143814 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        $this->addSql("
+            ALTER TABLE ujm_paper 
+            DROP FOREIGN KEY FK_82972E4BE934951A
+        ");
+        $this->addSql("
+            ALTER TABLE ujm_paper 
+            ADD CONSTRAINT FK_82972E4BE934951A FOREIGN KEY (exercise_id) 
+            REFERENCES ujm_exercise (id) 
+            ON DELETE SET NULL
+        ");
+    }
+
+    public function down(Schema $schema)
+    {
+        $this->addSql("
+            ALTER TABLE ujm_paper 
+            DROP FOREIGN KEY FK_82972E4BE934951A
+        ");
+        $this->addSql("
+            ALTER TABLE ujm_paper 
+            ADD CONSTRAINT FK_82972E4BE934951A FOREIGN KEY (exercise_id) 
+            REFERENCES ujm_exercise (id)
+        ");
+    }
+}


### PR DESCRIPTION
La pr n'est qu'un prétexte pour discuter de cette ligne.

Pourquoi un exit(); ? Cette fonction arrête tout simplement le script php, donc rien ne se passe par la suite.
Concrètement, je suis en train d'essayer de supprimer un WS. L'exécution du code fini par arriver ici et voilà. Tout s'arrête et rien n'a été supprimé (car la suppression se trouve dans une grosse transaction).
Et même s'il n'y avait pas de transaction à cet endroit, il faudrait le faire en 2x car lors du premier essai, le exit ferait tout rater.

Je suppose que vous vouliez plutôt faire ça non ? un SET NULL sur l'exercice de l'entity Paper en cas de suppression.