### PR TITLE
Fix issue#75

### DIFF
--- a/Resources/public/js/angular/Correction/Partials/correction.graphic.html
+++ b/Resources/public/js/angular/Correction/Partials/correction.graphic.html
@@ -1,5 +1,5 @@
 <div class="row">
-    <div class="col-md-12 center-text">
+    <div class="col-md-12">
         <div class="droppable-container" id="document-img-container-{{correctionGraphicCtrl.question.id}}">                    
             <img id="document-img-{{correctionGraphicCtrl.question.id}}" alt="{{correctionGraphicCtrl.question.document.label}}" width="{{correctionGraphicCtrl.question.width}}" height="{{correctionGraphicCtrl.question.height}}" src="{{correctionGraphicCtrl.getAssetsDir()}}{{correctionGraphicCtrl.question.document.url}}" />  
         </div>


### PR DESCRIPTION
This commit fixes claroline/Distribution#75

We center the picture in the correction page, so that there won't be any gap between the shown answer zones and the real ones.